### PR TITLE
ScanVolumes: Do not filter out multiple ESP partitions

### DIFF
--- a/MainRP/lib.c
+++ b/MainRP/lib.c
@@ -1541,6 +1541,8 @@ ScanVolumes (
                 MsgLog ("\n");
             }
             CHAR16 *VolDesc = Volume->VolName;
+            CHAR16* VolGUID = GuidAsString(&Volume->VolUuid);
+            CHAR16* PartGUID = GuidAsString(&Volume->PartGuid);
             if (MyStrStr (VolDesc, L"whole disk Volume") != NULL) {
                 VolDesc = L"Whole Disk Volume";
             }
@@ -1578,7 +1580,9 @@ ScanVolumes (
                 VolDesc = L"ISO-9660 Volume";
             }
 
-            MsgLog ("Add to Collection:- '%s'", VolDesc);
+            MsgLog ("Add to Collection:- '%s' '%s' '%s' '%s'", VolDesc, Volume->PartName, VolGUID, PartGUID);
+            MyFreePool(VolGUID);
+            MyFreePool(PartGUID);
             ScannedOnce = TRUE;
         }
         #endif


### PR DESCRIPTION
Honestly, I'm not sure exactly why we're deduplicating here at all, but deduplicating by VolUuid makes it impossible to use bootloaders on multiple EFI partitions, at least of the standard type.