### PR TITLE
Fix pointer reset

### DIFF
--- a/BootMaster/pointer.c
+++ b/BootMaster/pointer.c
@@ -433,18 +433,18 @@ EFI_STATUS pdUpdateState (VOID) {
             if (!EFI_ERROR(PointerStatus)) {
 #ifndef EFI32
                 TargetX = State.X + SPointerState.RelativeMovementX *
-                    GlobalConfig.MouseSpeed / ProtocolS[Index]->Mode->ResolutionX;
-                TargetY = State.Y + SPointerState.RelativeMovementY *
-                    GlobalConfig.MouseSpeed / ProtocolS[Index]->Mode->ResolutionY;
+                (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionX;
+                TargetY = (INTN)State.Y + SPointerState.RelativeMovementY *
+                (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionY;
 #else
                 TargetX = State.X + (INTN) DivS64x64Remainder (
-                    SPointerState.RelativeMovementX * GlobalConfig.MouseSpeed,
-                    ProtocolS[Index]->Mode->ResolutionX,
+                    SPointerState.RelativeMovementX * (INTN)GlobalConfig.MouseSpeed,
+                    (INT64)ProtocolS[Index]->Mode->ResolutionX,
                     NULL
                 );
                 TargetY = State.Y + (INTN) DivS64x64Remainder (
-                    SPointerState.RelativeMovementY * GlobalConfig.MouseSpeed,
-                    ProtocolS[Index]->Mode->ResolutionY,
+                    SPointerState.RelativeMovementY * (INTN)GlobalConfig.MouseSpeed,
+                    (INT64)ProtocolS[Index]->Mode->ResolutionY,
                     NULL
                 );
 #endif

--- a/BootMaster/pointer.c
+++ b/BootMaster/pointer.c
@@ -399,21 +399,16 @@ EFI_STATUS pdUpdateState (VOID) {
                 ProtocolA[Index]->GetState, ProtocolA[Index], &APointerState
             );
             if (!EFI_ERROR(PointerStatus)) {
-#ifndef EFI32
-                State.X = (APointerState.CurrentX * ScreenW) / ProtocolA[Index]->Mode->AbsoluteMaxX;
-                State.Y = (APointerState.CurrentY * ScreenH) / ProtocolA[Index]->Mode->AbsoluteMaxY;
-#else
                 State.X = (UINTN) DivU64x64Remainder (
-                    APointerState.CurrentX * ScreenW,
-                    ProtocolA[Index]->Mode->AbsoluteMaxX,
+                    (UINT64)APointerState.CurrentX * (UINT64)ScreenW,
+                    (UINT64)ProtocolA[Index]->Mode->AbsoluteMaxX,
                     NULL
                 );
                 State.Y = (UINTN) DivU64x64Remainder (
-                    APointerState.CurrentY * ScreenH,
-                    ProtocolA[Index]->Mode->AbsoluteMaxY,
+                    (UINT64)APointerState.CurrentY * (UINT64)ScreenH,
+                    (UINT64)ProtocolA[Index]->Mode->AbsoluteMaxY,
                     NULL
                 );
-#endif
 
                 State.Holding = (APointerState.ActiveButtons & EFI_ABSP_TouchActive);
                 Status = EFI_SUCCESS;
@@ -427,27 +422,19 @@ EFI_STATUS pdUpdateState (VOID) {
         }
 
         for (Index = 0; Index < NumSPointerDevices; Index++) {
-            PointerStatus = REFIT_CALL_2_WRAPPER(
-                ProtocolS[Index]->GetState, ProtocolS[Index], &SPointerState
-            );
+            PointerStatus = REFIT_CALL_2_WRAPPER(ProtocolS[Index]->GetState, ProtocolS[Index], &SPointerState);
+
             if (!EFI_ERROR(PointerStatus)) {
-#ifndef EFI32
-                TargetX = State.X + SPointerState.RelativeMovementX *
-                (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionX;
-                TargetY = State.Y + SPointerState.RelativeMovementY *
-                (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionY;
-#else
-                TargetX = State.X + (INTN) DivS64x64Remainder (
-                    SPointerState.RelativeMovementX * (INTN)GlobalConfig.MouseSpeed,
+                TargetX = (INT32)((INT64)State.X + DivS64x64Remainder (
+                    (INT64)SPointerState.RelativeMovementX * (INT64)GlobalConfig.MouseSpeed,
                     (INT64)ProtocolS[Index]->Mode->ResolutionX,
                     NULL
-                );
-                TargetY = State.Y + (INTN) DivS64x64Remainder (
-                    SPointerState.RelativeMovementY * (INTN)GlobalConfig.MouseSpeed,
+                ));
+                TargetY = (INT32)((INT64)State.Y + DivS64x64Remainder (
+                    (INT64)SPointerState.RelativeMovementY * (INT64)GlobalConfig.MouseSpeed,
                     (INT64)ProtocolS[Index]->Mode->ResolutionY,
                     NULL
-                );
-#endif
+                ));
 
                 if (TargetX < 0) {
                     State.X = 0;

--- a/BootMaster/pointer.c
+++ b/BootMaster/pointer.c
@@ -434,7 +434,7 @@ EFI_STATUS pdUpdateState (VOID) {
 #ifndef EFI32
                 TargetX = State.X + SPointerState.RelativeMovementX *
                 (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionX;
-                TargetY = (INTN)State.Y + SPointerState.RelativeMovementY *
+                TargetY = State.Y + SPointerState.RelativeMovementY *
                 (INTN)GlobalConfig.MouseSpeed / (INT64)ProtocolS[Index]->Mode->ResolutionY;
 #else
                 TargetX = State.X + (INTN) DivS64x64Remainder (


### PR DESCRIPTION
Currently, the pointer resets to the edge of the screen when the mouse is moved left or up due to implicit conversions.