### PR TITLE
Fix Issues With 'banner_scale' Config Setting

### DIFF
--- a/BootMaster/config.c
+++ b/BootMaster/config.c
@@ -3189,7 +3189,7 @@ VOID ReadConfig (
             }
             #endif
 
-            Flag = TokenList[i];
+            Flag = TokenList[1];
             if (MyStriCmp (Flag, L"noscale")) {
                 GlobalConfig.BannerScale = BANNER_NOSCALE;
             }

--- a/BootMaster/scan.c
+++ b/BootMaster/scan.c
@@ -791,7 +791,7 @@ VOID GenerateSubScreen (
                     LOG_SEP(L"X");
                 } // while
                 BREAD_CRUMB(L"%a:  2a 8", __func__);
-                FreeTokenLine (&TokenList, &TokenCount);
+                //FreeTokenLine (&TokenList, &TokenCount);
 
                 BREAD_CRUMB(L"%a:  2a 9", __func__);
                 MY_FREE_POOL(KernelVersion);


### PR DESCRIPTION
This change fixes an issue when banner_scale is active:
- Freeze when activated in config.conf.
- Warning and garbaged token when active in included theme config.

Fixes #235