### PR TITLE
feat: add NetBSD EFI loader detection

### DIFF
--- a/BootMaster/scan.c
+++ b/BootMaster/scan.c
@@ -1856,6 +1856,18 @@ VOID SetLoaderDefaults (
             GotFlag       = TRUE;
             Entry->OSType =  'B';
         }
+        else if (IsStriStr (LoaderPath, L"\\NetBSD\\")) {
+            BREAD_CRUMB(L"%a:  5i_nbsd 1", __func__);
+            if (GetImage) {
+                MergeUniqueStrings (
+                    &TmpIconName, L"netbsd", L','
+                );
+            }
+
+            BREAD_CRUMB(L"%a:  5i_nbsd 2", __func__);
+            GotFlag       = TRUE;
+            Entry->OSType =  'B';
+        }
         else if (MyStriCmp (NameClues, L"diags.efi")) {
             BREAD_CRUMB(L"%a:  5j 1", __func__);
             if (GetImage) {


### PR DESCRIPTION
Detect \NetBSD\ path in loader and assign netbsd icon and OSType 'B', consistent with existing FreeBSD and DragonFly BSD handling.

I will add OpenBSD in separate PR . (image is missing).